### PR TITLE
Make message serialization more deterministic (issue #7)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Individual Contributors
 =======================
 Sam Russell <sam.h.russell@gmail.com>
+Bill Fisher <william.w.fisher@gmail.com>

--- a/beka/bgp_message.py
+++ b/beka/bgp_message.py
@@ -130,7 +130,7 @@ def pack_capabilities(capabilities):
             packed_header = struct.pack("!BB", capability_code, len(packed_body))
             packed_capability_list.append(packed_header + packed_body)
 
-    packed_capabilities = b"".join(packed_capability_list)
+    packed_capabilities = b"".join(sorted(packed_capability_list))
     return packed_capabilities
 
 def merge_dict_of_lists(main_dict, new_dict):

--- a/beka/state_machine.py
+++ b/beka/state_machine.py
@@ -1,4 +1,5 @@
 from eventlet.queue import Queue
+from collections import OrderedDict
 
 from .event import Event
 from .bgp_message import BgpMessage, BgpOpenMessage, BgpUpdateMessage
@@ -212,19 +213,14 @@ class StateMachine:
 
     def build_ipv4_update_messages(self, ipv4_route_additions):
         update_messages = []
-        nlri_by_path = {}
+        nlri_by_path = OrderedDict()
         for route_addition in ipv4_route_additions:
-            path_attributes = {
-                "next_hop": route_addition.next_hop,
-                "as_path": route_addition.as_path,
-                "origin": route_addition.origin
-            }
-            path_key = tuple(path_attributes.items())
-
-            if path_key not in nlri_by_path:
-                nlri_by_path[path_key] = []
-
-            nlri_by_path[path_key].append(route_addition.prefix)
+            path_key = (
+                ("next_hop", route_addition.next_hop),
+                ("as_path", route_addition.as_path),
+                ("origin", route_addition.origin)
+            )
+            nlri_by_path.setdefault(path_key, []).append(route_addition.prefix)
 
         for path_attributes, nlri in nlri_by_path.items():
             update_messages.append(BgpUpdateMessage([], dict(path_attributes), nlri))
@@ -233,19 +229,14 @@ class StateMachine:
 
     def build_ipv6_update_messages(self, ipv6_route_additions):
         update_messages = []
-        nlri_by_path = {}
+        nlri_by_path = OrderedDict()
         for route_addition in ipv6_route_additions:
-            path_attributes = {
-                "next_hop": route_addition.next_hop,
-                "as_path": route_addition.as_path,
-                "origin": route_addition.origin
-            }
-            path_key = tuple(path_attributes.items())
-
-            if path_key not in nlri_by_path:
-                nlri_by_path[path_key] = []
-
-            nlri_by_path[path_key].append(route_addition.prefix)
+            path_key = (
+                ("next_hop", route_addition.next_hop),
+                ("as_path", route_addition.as_path),
+                ("origin", route_addition.origin)
+            )
+            nlri_by_path.setdefault(path_key, []).append(route_addition.prefix)
 
         for path_attributes, nlri in nlri_by_path.items():
             path_attributes_dict = dict(path_attributes)


### PR DESCRIPTION
Fix issues where message serialization depends on Python dict ordering,
which differs in behavior with Python 3.5 -> 3.6.